### PR TITLE
fix: check NoneType webSocket message

### DIFF
--- a/terncy/terncy.py
+++ b/terncy/terncy.py
@@ -217,7 +217,14 @@ class Terncy:
                     _LOGGER.info(f"connected to {self.dev_id}")
                     self._event_handler(self, event.Connected())
                 async for msg in ws:
-                    msgObj = json.loads(msg)
+                    try:
+                        msgObj = json.loads(msg)
+                    except Exception as e:
+                        _LOGGER.warning(f"Failed to parse message: {msg}, error: {e}")
+                        continue
+                    if not isinstance(msgObj, dict):
+                        _LOGGER.warning(f"Received non-dict message: {msgObj}")
+                        continue
                     _LOGGER.debug(f"recv {self.dev_id} msg: {msgObj}")
                     if "rspId" in msgObj:
                         rsp_id = msgObj["rspId"]


### PR DESCRIPTION
https://github.com/rxwen/homeassistant-terncy-component/issues/120#issuecomment-3169663537

```
2025-08-07 21:26:19.211 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/terncy/terncy.py", line 201, in start
    return await self._start_websocket()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/terncy/terncy.py", line 222, in _start_websocket
    if "rspId" in msgObj:
       ^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

根据这份日志，似乎网关回复了空的消息导致解析错误。

这里先简单过滤一下错误的情况，看看能不能解决问题。